### PR TITLE
v13.1.11 fix Wild Shape attack calculation

### DIFF
--- a/_functions/AbilityScores.js
+++ b/_functions/AbilityScores.js
@@ -456,21 +456,37 @@ function AbilityScores_Button(onlySetTooltip) {
 				var res = dialog.store();
 				// Save to the global variable
 				this.setCurrentStats(dialog);
+				// See if any stats changed
+				var statChange = { any : false, con : false, mental : false };
+				for (var s = 0; s < 7; s++) {
+					var abbr2 = asab2[s];
+					if (res["ol"+abbr2] != res["to"+abbr2]) {
+						statChange.any = true;
+						if (abbr2 == "Cn") {
+							statChange.con = true;
+						} else if (!statChange.mental && /In|Ws|Ch/.test(abbr2)) {
+							statChange.mental = true;
+						}
+					}
+				}
+				if (!statChange.any) return; // no totals changed
 				// Start progress bar and stop calculations
 				var thermoTxt = thermoM("Applying stats...");
 				calcStop();
 				// Set the new ability scores to the fields (and their mods, so functions use the new one)
 				for (var s = 0; s < 7; s++) {
-					var theAbi = res["to"+asab2[s]];
+					var theAbi = Number(res["to"+asab2[s]]);
 					Value(asab3[s], theAbi);
-					Value(asab3[s] + " Mod", Math.round((Number(theAbi) - 10.5) * 0.5));
+					Value(asab3[s] + " Mod", Math.round((theAbi - 10.5) * 0.5));
 				}
 				// Update the Honor/Sanity
 				if (this.fieldHoS !== curHoS) ShowHonorSanity(this.fieldHoS);
 				// Apply HP tooltips if Con changed
-				if (res["olCn"] != res["toCn"]) CurrentUpdates.types.push("hp");
+				if (statChange.con) CurrentUpdates.types.push("hp");
 				// Recalculate attack entries, as they might have changed (Finesse)
 				CurrentUpdates.types.push("attacks");
+				// Recalculate wild shapes, if the mental stats changed
+				if (statChange.mental) WildshapeRecalc();
 				thermoM(thermoTxt, true); // Stop progress bar
 			},
 

--- a/_functions/FunctionsImport.js
+++ b/_functions/FunctionsImport.js
@@ -2651,6 +2651,8 @@ function deleteUnknownReferences() {
 		for (var i = oClass.subclasses[1].length - 1; i >= 0; i--) {
 			var sSubcl = oClass.subclasses[1][i];
 			if (!ClassSubList[sSubcl] || arrDupl.indexOf(sSubcl) !== -1) {
+				console.println("The subclass '" + sSubcl + "' for the class '" + oClass.name + "' is missing from the ClassSubList object, or appears multiple times in the `subclasses` attribute. Please contact its author to have this issue corrected. The subclass will be ignored for now.\nBe aware that if you add a subclass using the `AddSubClass()` function, you shouldn't list it in the `subclasses` attribute, the function will take care of that.");
+				console.show();
 				oClass.subclasses[1].splice(i, 1);
 			} else {
 				arrDupl.push(sSubcl);

--- a/_functions/FunctionsResources.js
+++ b/_functions/FunctionsResources.js
@@ -1001,6 +1001,7 @@ function resourceSelectionDialog(type) {
 			if (!inclObj[uGroup]) inclObj[uGroup] = {};
 			for (var z = 0; z < ClassList[u].subclasses[1].length; z++) {
 				var uSub = ClassList[u].subclasses[1][z];
+				if (!ClassSubList[uSub]) continue;
 				uSubTest = testSource(uSub, ClassSubList[uSub], CSatt, true);
 				if (uSubTest === "source") continue;
 				var uName = amendSource(ClassSubList[uSub].subname, ClassSubList[uSub], ClassList[u]);
@@ -1039,6 +1040,7 @@ function resourceSelectionDialog(type) {
 				for (var z = 0; z < rLen + 1; z++) {
 					var uSub = z === rLen ? u : u + "-" + RaceList[u].variants[z];
 					var uRaceVar = z === rLen ? RaceList[u] : RaceSubList[uSub];
+					if (!uRaceVar) continue;
 					var uSubTest = testSource(uSub, uRaceVar, CSatt, true);
 					if (uSubTest === "source") continue;
 					doAny = z !== rLen ? true : doAny;
@@ -1084,8 +1086,9 @@ function resourceSelectionDialog(type) {
 				for (var z = 0; z < rLen; z++) {
 					var uSub = parObj[u].choices[z];
 					var uSubL = uSub.toLowerCase();
-					var uSubVar = parObj[u][uSubL];
 					var uSubRef = u + "-" + uSubL;
+					var uSubVar = parObj[u][uSubL];
+					if (!uSubVar) continue;
 					var uSubTest = testSource(uSubRef, uSubVar.source ? uSubVar : parObj[u], CSatt, true);
 					if (uSubTest === "source") continue;
 					var uName = amendSource(uSubVar.name ? uSubVar.name : uSub, uSubVar, parObj[u]);
@@ -1137,9 +1140,11 @@ function resourceSelectionDialog(type) {
 			if (BackgroundList[u].variant) {
 				for (var z = 0; z < BackgroundList[u].variant.length; z++) {
 					var uSub = BackgroundList[u].variant[z];
-					var uSubTest = testSource(uSub, BackgroundSubList[uSub], CSatt, true);
+					var uSubVar = BackgroundSubList[uSub];
+					if (!uSubVar) continue;
+					var uSubTest = testSource(uSub, uSubVar, CSatt, true);
 					if (uSubTest === "source") continue;
-					var uSubName = amendSource(BackgroundSubList[uSub].name, BackgroundSubList[uSub], BackgroundList[u]);
+					var uSubName = amendSource(uSubVar.name, uSubVar, BackgroundList[u]);
 					refObj[uSubName] = uSub;
 					if (uSubTest) {
 						exclObj[uSubName] = -1;

--- a/_variables/Lists.js
+++ b/_variables/Lists.js
@@ -809,7 +809,7 @@ var SetPrintPages_Dialog = {
 						}, {
 							type : "check_box",
 							item_id : "Pag3",
-							name : (typePF ? "Feats" : "Conditions") + "/magic items page"
+							name : "Additional sheet (" + (typePF ? "feats" : "conditions") + "/magic items)"
 						}, {
 							type : "check_box",
 							item_id : "Pa10",

--- a/_variables/ListsCreatures.js
+++ b/_variables/ListsCreatures.js
@@ -1522,7 +1522,7 @@ var Base_CreatureList = {
 		}, {
 			name : "Cinder Breath (Recharge 6)",
 			ability : 3,
-			damage : ["Dex Save", "", "Blinded"],
+			damage : ["Dex save", "", "Blinded"],
 			range : "15-ft cone",
 			description : "Hits all in area; Dex save or blinded until the end of the next turn",
 			dc : true,
@@ -1620,12 +1620,11 @@ var Base_CreatureList = {
 			tooltip : "If the target is a creature, it must succeed on a DC 15 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic."
 		}, {
 			name : "Haste (Recharge 5-6)",
-			ability : "",
+			ability : 0,
 			damage : ["", "", ""],
 			range : "Self",
 			description : "+2 AC, adv. on Dex saves, and can Slam as a bonus action until the end of its next turn",
 			abilitytodamage : false,
-			dc : false,
 			tooltip : "Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."
 		}],
 		traits : [{
@@ -2354,7 +2353,7 @@ var Base_CreatureList = {
 		}],
 		traits : [{
 			name : "Hold Breath",
-			description : "The crocodile can hold its breath for 15 minutes."
+			description : "The [THIS] can hold its breath for 15 minutes."
 		}]
 	},
 	"death dog" : {
@@ -2550,8 +2549,8 @@ var Base_CreatureList = {
 	},
 	"elk" : {
 		name : "Elk",
-		nameAlt : ["Reindeer"],
-		source : [["SRD", 372], ["M", 322]],
+		nameAlt : ["Reindeer"], // from Icewind Dale: Rime of the Frostmaiden
+		source : [["SRD", 372], ["M", 322], ["RotF", 107]],
 		size : 2, //Large
 		type : "Beast",
 		companion : "mount",
@@ -2884,8 +2883,8 @@ var Base_CreatureList = {
 	},
 	"giant crocodile" : {
 		name : "Giant Crocodile",
-		nameAlt : ["Crocodile, Giant"],
-		source : [["SRD", 374], ["M", 324]],
+		nameAlt : ["Crocodile, Giant", "Whirlwyrm"], // Whirlwyrm from Turn of Fortune's Wheel (Planescape)
+		source : [["SRD", 374], ["M", 324], ["P:AitM", 0]],
 		size : 1, //Huge
 		type : "Beast",
 		alignment : "Unaligned",
@@ -2917,10 +2916,10 @@ var Base_CreatureList = {
 		}],
 		traits : [{
 			name : "Hold Breath",
-			description : "The crocodile can hold its breath for 30 minutes."
+			description : "The [THIS] can hold its breath for 30 minutes."
 		}, {
 			name : "Multiattack",
-			description : "The crocodile makes two attacks: one with its bite and one with its tail (to a target it is not grappling)."
+			description : "The [THIS] makes two attacks: one with its bite and one with its tail (to a target it is not grappling)."
 		}]
 	},
 	"giant eagle" : {
@@ -3095,8 +3094,8 @@ var Base_CreatureList = {
 	},
 	"giant goat" : {
 		name : "Giant Goat",
-		nameAlt : ["Goat, Giant", "Moose"],
-		source : [["SRD", 376], ["M", 326]],
+		nameAlt : ["Goat, Giant", "Moose"], // Moose from Icewind Dale: Rime of the Frostmaiden
+		source : [["SRD", 376], ["M", 326], ["RotF", 80]],
 		size : 2, //Large
 		type : "Beast",
 		alignment : "Unaligned",
@@ -3737,7 +3736,7 @@ var Base_CreatureList = {
 	},
 	"hawk" : {
 		name : "Hawk",
-		nameAlt : ["Falcon"],
+		nameAlt : ["Falcon"], // from Waterdeep: Dragon Heist
 		source : [["SRD", 382], ["M", 330], ["WDH", 53]],
 		size : 5, //Tiny
 		type : "Beast",
@@ -4358,7 +4357,7 @@ var Base_CreatureList = {
 	},
 	"raven" : {
 		name : "Raven",
-		nameAlt : ["Crow"],
+		nameAlt : ["Crow"], // from Waterdeep: Dungeon of the Mad Mage
 		source : [["SRD", 387], ["M", 335], ["WDotMM", 302]],
 		size : 5, //Tiny
 		type : "Beast",
@@ -4641,7 +4640,7 @@ var Base_CreatureList = {
 	},
 	"tiger" : {
 		name : "Tiger",
-		nameAlt : ["Snow Leopard", "Leopard, Snow"],
+		nameAlt : ["Snow Leopard", "Leopard, Snow"], // from Tales from the Yawning Portal
 		source : [["SRD", 391], ["M", 339], ["TftYP", 183]],
 		size : 2, //Large
 		type : "Beast",
@@ -4683,7 +4682,7 @@ var Base_CreatureList = {
 	},
 	"vulture" : {
 		name : "Vulture",
-		nameAlt : ["Peacock"],
+		nameAlt : ["Peacock"], // from Baldur's Gate: Descend into Avernus
 		source : [["SRD", 392], ["M", 339], ["DiA", 195]],
 		size : 3, //Medium
 		type : "Beast",
@@ -4782,7 +4781,7 @@ var Base_CreatureList = {
 	},
 	"wolf" : {
 		name : "Wolf",
-		nameAlt : ["Sled Dog", "Dog, Sled"],
+		nameAlt : ["Sled Dog", "Dog, Sled"], // from Rise of Tiamat
 		source : [["SRD", 393], ["M", 341], ["RoT", 27]],
 		size : 3, //Medium
 		type : "Beast",

--- a/_variables/ListsMagicItems.js
+++ b/_variables/ListsMagicItems.js
@@ -1258,8 +1258,8 @@ var Base_MagicItemsList = {
 		rarity : "very rare",
 		magicItemTable : "H",
 		attunement : true,
-		description : "As a bonus action, I can toss this sword into the air and use the command to make it hover, fly up to 30 ft and attack a target of my choice (as if I'm using it).\nI can command it to move/attack again as a bonus action while it hovers and is in 30 ft.\nAfter the 4th attack, it moves 30 ft to return to my hand.",
-		descriptionLong : "As a bonus action, I can toss this magic sword into the air and use the command word to make it hover, fly up to 30 ft and attack a target of my choice within 5 ft of it.\nThe attack uses my attack roll and ability score for damage as if I would be using the sword.\nI can command it to move and attack again as a bonus action while it hovers.\nAfter the 4th attack, it moves 30 ft to try and return to my hand.\nIf it can't reach me or my hands are full, it falls to the ground after moving.\nIt also ceases to hover if I grasp it or move more than 30 ft away from it.",
+		description : "As a bonus action, I can toss this sword into the air and use the command to make it hover, fly up to 30 ft and attack a target of my choice (as if I'm using it)." + (typePF ? " " : "\n") + "I can command it to move/attack again as a bonus action while it hovers and is in 30 ft.\nAfter the 4th attack, it moves 30 ft to return to my hand.",
+		descriptionLong : "As a bonus action, I can toss this magic sword into the air and use the command word to make it hover, fly up to 30 ft and attack a target of my choice within 5 ft of it." + (typePF ? " " : "\n") + "The attack uses my attack roll and ability score for damage as if I would be using the sword.\nI can command it to move and attack again as a bonus action while it hovers.\nAfter the 4th attack, it moves 30 ft to try and return to my hand.\nIf it can't reach me or my hands are full, it falls to the ground after moving.\nIt also ceases to hover if I grasp it or move more than 30 ft away from it.",
 		descriptionFull : "You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.\n   While the sword hovers, you can use a bonus action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same bonus action, you can cause the sword to attack one creature within 5 feet of it.\n   After the hovering sword attacks for the fourth time, it flies up to 30 feet and tries to return to your hand. If you have no hand free, it falls to the ground at your feet. If the sword has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or move more than 30 feet away from it.",
 		action : [["bonus action", ""]],
 		chooseGear : {
@@ -2346,8 +2346,8 @@ var Base_MagicItemsList = {
 			spells : ["disguise self"],
 			selection : ["disguise self"],
 			firstCol : "atwill"
-	   }],
-	   spellcastingAbility : "class" // https://www.sageadvice.eu/2015/11/27/hat-of-disguise-dc/
+		}],
+		spellcastingAbility : "class" // https://www.sageadvice.eu/2015/11/27/hat-of-disguise-dc/
 	},
 	"headband of intellect" : {
 		name : "Headband of Intellect",

--- a/additional content syntax/creature, wild shape option (CreatureList).js
+++ b/additional content syntax/creature, wild shape option (CreatureList).js
@@ -42,7 +42,7 @@
 	        	You will also need the syntax for common attributes if you want to use a
 	        	custom calculation for hit points (calcChanges.hp).
 
-	Sheet:		v13.1.0 and newer
+	Sheet:		v13.1.11 and newer
 
 */
 
@@ -60,7 +60,7 @@ var iFileName = "Homebrew Syntax - CreatureList.js";
 	Only the first occurrence of this variable will be used.
 */
 
-RequiredSheetVersion("13.0.6");
+RequiredSheetVersion("13.1.11");
 /*	RequiredSheetVersion // OPTIONAL //
 	TYPE:	function call with one variable, a string or number
 	USE:	the minimum version of the sheet required for the import script to work
@@ -584,12 +584,23 @@ CreatureList["purple crawler"] = {
 			PickDropdown(prefix + "Comp.Desc.Size", 3);
 		}
 	}],
+	notes : [{
+		name : "Lila Laser Light (Purplemancer 13)",
+		minlevel : 13,
+		description : desc([
+			"The purple companion gains the ability to shine in a bright purple color",
+			"Once per long rest, it can cast Hypnotic Pattern without requiring components"
+		]),
+		joinString : ""
+	}],
 /*	features // OPTIONAL //
 	actions  // OPTIONAL //
 	traits   // OPTIONAL //
+	notes   // OPTIONAL // since v13.1.11
 	TYPE:	array (variable length) with objects
 	USE:	add text to the Traits and Features sections on the Companion page
 	CHANGE:	v13.1.0 (added `joinString` attribute)
+	CHANGE:	v13.1.11 (added `notes`)
 
 	Each of these three attributes work in the same way.
 	Each is an array with objects that have at least two attributes, `name` and `description`, that each contain a string.
@@ -632,17 +643,27 @@ CreatureList["purple crawler"] = {
 	 features		 Features
 	 actions 		 Traits
 	 traits  		 Traits
+	 notes  		 Notes (left)
 
+	> `features`
 	Be aware that languages, resistances, vulnerabilities, and immunities are also added to the
 	Features section on the companion page and before the features attribute described here.
 
+	> `actions` & `traits`
 	The actions are added before traits to the Traits section.
+
+	> `notes`
+	Starting with v13.1.11, the array in `notes` is added to the notes section before any notes from a
+	CompanionList selection are added.
+	Be aware that if you add anything in the `notes` of a CreatureList object, some CompanionList options
+	will run out of space for all their notes.
+	Notes are not displayed on the wild shape page.
 
 	The array is processed in the order it is in the code, no sorting will take place.
 
-	These text are also displayed on the wild shape page, but all together in the singular Traits & Features section,
-	regardless of their `minlevel` attribute value.
-	Also, `eval` and `changeeval` are not executed when this creature is selected on the Wild Shape page.
+	These text, except `notes`, are also displayed on the wild shape page, but all together in the singular
+	Traits & Features section,	regardless of their `minlevel` attribute value.
+	Also, `eval`, `removeeval`, and `changeeval` are not executed when this creature is selected/removed on the Wild Shape page.
 	As the wild shape pages offer limited space, it is recommended to test if all of
 	these and the other attributes together will fit.
 	If they don't fit (well), consider using the `wildshapeString` attribute, see below.
@@ -657,12 +678,12 @@ CreatureList["purple crawler"] = {
 */
 
 /*	minlevel // OPTIONAL //
-	(Part of `features`, `traits`, or `actions` object, see above)
+	(Part of `features`, `traits`, `actions`, or `notes` object, see above)
 	TYPE:	number
 	USE:	the level at which to add the feature, trait, or action
 	ADDED:	v13.0.6
 
-	This attribute is part of an object in the `features`, `traits`, or `actions` arrays, see above.
+	This attribute is part of an object in the `features`, `traits`, `actions`, or `notes` arrays, see above.
 	Use this if an entry in that array is only supposed to be displayed
 	once the main character (the character on the 1st page) reaches a certain level.
 	If the main character goes below this level, the entry is removed again.
@@ -673,16 +694,16 @@ CreatureList["purple crawler"] = {
 */
 
 /*	eval & removeeval & addMod // OPTIONAL //
-	(Part of `features`, `traits`, or `actions` object, see above)
+	(Part of `features`, `traits`, `actions`, or `notes` object, see above)
 	TYPE:	variable, see the entries for `eval`, `removeeval`, or `addMod`
 	USE:	variable, see the entries for `eval`, `removeeval`, or `addMod`
 	ADDED:	v13.0.6
 
-	These attributes are part of an object in the `features`, `traits`, or `actions` arrays, see above.
+	These attributes are part of an object in the `features`, `traits`, `actions`, or `notes` arrays, see above.
 	These optional attributes function identical to those that share their name.
 	They function exactly as described for the main object, but they will only be called when the
-	`features`, `traits`, or `actions` object is processed, which can be influenced using the
-	`minlevel` attribute, see above.
+	`features`, `traits`, `actions`, or `notes` object is processed, which can be influenced
+	using the `minlevel` attribute, see above.
 */
 
 	minlevelLinked : ["artificer", "wizard"],
@@ -705,7 +726,7 @@ CreatureList["purple crawler"] = {
 	2. function that returns the number
 		The function is called upon any time a level needs to be determined for the creature,
 		be it to determine which level to pass to `changeeval` (see below),
-		or to determine which `features`, `traits`, or `actions` to add.remove (see `minlevel` above).
+		or to determine which `features`, `traits`, `actions`, or `notes` to add.remove (see `minlevel` above).
 		It is passed one variable: a string: the prefix of the Companion page this creature was selected on.
 		If it returns false, 0, "", or anything that is not a number, the sheet will default
 		to the total class level, or 1 if the level field is empty.
@@ -786,7 +807,10 @@ CreatureList["purple crawler"] = {
 	},
 
 	eval : function(prefix, lvl) {
-		AddString(prefix + 'Cnote.Left', 'The purple crawler always serves a singular master. If that master gets killed, it will serve the one who killed its master, if any.', true);
+		var fldName = prefix + "Comp.Use.Speed";
+		var newSpeed = "40 ft, fly 60 ft, swim 40 ft";
+		if (What("Unit System") === "metric") newSpeed = ConvertToMetric(newSpeed, 0.5);
+		Value(fldName, newSpeed);
 	},
 /*	eval // OPTIONAL //
 	TYPE:	function
@@ -795,7 +819,7 @@ CreatureList["purple crawler"] = {
 	The function is passed two variables:
 	1) The first variable is a string: the prefix of the Companion page this creature was selected on
 		You can use this variable to call on fields on that page. The example above uses it to set
-		a string to the leftmost Notes section on the Companion page.
+		the speed to something else.
 	2) The second variable is an array with 2 numbers: the old level and the new level
 		e.g. lvl = [0,5] when the creature gets added and the character is 5th level
 		The first entry, the old level, is the level that was passed as the second entry the last time
@@ -810,7 +834,10 @@ CreatureList["purple crawler"] = {
 */
 
 	removeeval : function(prefix, lvl) {
-		RemoveString(prefix + 'Cnote.Left', 'The purple crawler always serves a singular master. If that master gets killed, it will serve the one who killed its master, if any.', true);
+		var fldName = prefix + "Comp.Use.Speed";
+		var newSpeed = "30 ft, fly 45 ft, swim 30 ft";
+		if (What("Unit System") === "metric") newSpeed = ConvertToMetric(newSpeed, 0.5);
+		Value(fldName, newSpeed);
 	},
 /*	removeeval // OPTIONAL //
 	TYPE:	function
@@ -818,8 +845,8 @@ CreatureList["purple crawler"] = {
 
 	The function is passed two variables:
 	1) The first variable is a string: the prefix of the Companion page this creature was selected on
-		You can use this variable to call on fields on that page. The example above uses it to remove
-		a string to the leftmost Notes section on the Companion page.
+		You can use this variable to call on fields on that page. The example above uses it to set
+		the speed to something else.
 	2) The second variable is an array with 2 numbers: the old level and the new level
 		e.g. lvl = [0,5] when the creature gets added and the character is 5th level
 		The first entry, the old level, is the level that the creature had before being removed.

--- a/additional content syntax/weapon (WeaponsList).js
+++ b/additional content syntax/weapon (WeaponsList).js
@@ -337,7 +337,8 @@ WeaponsList["sword of purple"] = {
 	This array has two entries:
 	1. string or number
 		The first entry is what to put in the To Hit modifier field.
-		If this starts with "dc", the To Hit will be calculated as a DC.
+		For backwards compatibility, if this starts with "dc", the To Hit will be calculated as a DC.
+		However, it is recommended to set the `dc` attribute to `true` if you want this to be a DC.
 	2. string or number
 		The second entry is what to put in the Damage modifier field.
 


### PR DESCRIPTION
•	Added better error handling for malformed choice/extrachoice/variant/subclass entries of classes, races, backgrounds, feats, and magic items. Now this will no longer cause the source selection dialog to error out. When selecting one of the above with such an erroneous sub-choice, a warning will display in the console. •	Added `notes` as an optional attribute to the CreatureList object. •	Added support for composite AC of the CreatureList object on the Wild Shape pages (e.g. `ac : "10+Dex"`). •	Changed how wild shapes attacks are calculated to fix a bug (see below) and adhere to the other attack sections so that more complex modifiers and non-numeric damage die entries work correctly. •	Made wild shapes recalculate when changing mental stats using the ability score dialog. •	Fixed ability save DCs on the first page using the wrong ability modifier when the corresponding entry on the spell sheet page uses a different ability score to determine the DC (MBUG-122). •	Fixed the listing of the “Additional Sheet” in the print dialog to be clearer. •	Fixed wild shapes attacks not listening to the right syntax for attacks and not being backwards-compatible. •	Fixed wild shapes not recalculating when used without the druid class being selected. •	Fixed wild shapes recalculating using the correct proficiency bonus when changing level. •	Fixed field filling issue for creatures, feats, and magic items that themselves add another of the same type using `eval` (e.g. a feat that adds another feat upon selection). Before, this could overwrite the first selection with one added through `eval`.